### PR TITLE
feat(03): add note table for private notepad

### DIFF
--- a/database/sql/note.sql
+++ b/database/sql/note.sql
@@ -1,0 +1,31 @@
+-- PostgreSQL
+create table if not exists public.note (
+  user_uuid uuid not null,
+  room_uuid uuid not null,
+  content text default '' not null,
+  created_at timestamp default current_timestamp not null,
+  updated_at timestamp default current_timestamp not null,
+  primary key (user_uuid, room_uuid)
+);
+alter table public.note
+add constraint note_user_uuid_fkey foreign key (user_uuid) references public.user (uuid) on update cascade on delete cascade;
+alter table public.note
+add constraint note_room_uuid_fkey foreign key (room_uuid) references public.room (uuid) on update cascade on delete cascade;
+
+-- 触发器：自动维护 updated_at
+create or replace function public.set_note_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = current_timestamp;
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists note_set_updated_at on public.note;
+create trigger note_set_updated_at
+before update on public.note
+for each row execute function public.set_note_updated_at();
+
+insert into public.note (user_uuid, room_uuid, content) values
+('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-100000000001', '记得带钥匙'),
+('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-100000000001', '明天交作业');


### PR DESCRIPTION
第3讲 Database 作业：便签纸功能的数据库设计

- 新增 note 表（user_uuid+room_uuid 联合主键，外键级联删除）
- created_at/updated_at 时间戳 + 触发器自动维护
- Hasura track + user 角色权限（select/insert/update 均限定 user_uuid=X-Hasura-User-Id），便签仅自己可见

关联 issue：#6