### PR TITLE
feat(04): add notepad routes GET/POST /note

### DIFF
--- a/backend/src/graphql.ts
+++ b/backend/src/graphql.ts
@@ -1627,6 +1627,45 @@ export const GetUsersByUsernameDocument = gql`
   }
 }
     `;
+export const GetNoteDocument = gql`
+    query getNote($user_uuid: uuid!, $room_uuid: uuid!) {
+  note(where: {user_uuid: {_eq: $user_uuid}, room_uuid: {_eq: $room_uuid}}) {
+    user_uuid
+    room_uuid
+    content
+    created_at
+    updated_at
+  }
+}
+    `;
+export const UpsertNoteDocument = gql`
+    mutation upsertNote($user_uuid: uuid!, $room_uuid: uuid!, $content: String!) {
+  insert_note_one(
+    object: {user_uuid: $user_uuid, room_uuid: $room_uuid, content: $content}
+    on_conflict: {constraint: note_pkey, update_columns: [content]}
+  ) {
+    user_uuid
+    room_uuid
+    content
+    updated_at
+  }
+}
+    `;
+
+export type GetNoteQueryVariables = Exact<{
+  user_uuid: Scalars['uuid']['input'];
+  room_uuid: Scalars['uuid']['input'];
+}>;
+
+export type GetNoteQuery = { note: Array<{ user_uuid: any, room_uuid: any, content: string, created_at: any, updated_at: any }> };
+
+export type UpsertNoteMutationVariables = Exact<{
+  user_uuid: Scalars['uuid']['input'];
+  room_uuid: Scalars['uuid']['input'];
+  content: Scalars['String']['input'];
+}>;
+
+export type UpsertNoteMutation = { insert_note_one?: { user_uuid: any, room_uuid: any, content: string, updated_at: any } | null };
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
@@ -1658,6 +1697,12 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
     },
     getUsersByUsername(variables: GetUsersByUsernameQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetUsersByUsernameQuery> {
       return withWrapper((wrappedRequestHeaders) => client.request<GetUsersByUsernameQuery>(GetUsersByUsernameDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getUsersByUsername', 'query', variables);
+    },
+    getNote(variables: GetNoteQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<GetNoteQuery> {
+      return withWrapper((wrappedRequestHeaders) => client.request<GetNoteQuery>(GetNoteDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'getNote', 'query', variables);
+    },
+    upsertNote(variables: UpsertNoteMutationVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<UpsertNoteMutation> {
+      return withWrapper((wrappedRequestHeaders) => client.request<UpsertNoteMutation>(UpsertNoteDocument, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'upsertNote', 'mutation', variables);
     }
   };
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,6 +7,7 @@ import { getSdk } from "./graphql";
 import userRouter from "./user";
 import fileRouter from "./file";
 import emailRouter from "./email";
+import noteRouter from "./note";
 
 const app = express();
 const address = "http://localhost";
@@ -41,6 +42,7 @@ app.use(express.json());
 app.use("/user", userRouter);
 app.use("/file", fileRouter);
 app.use("/email", emailRouter);
+app.use("/note", noteRouter);
 
 app.listen(port, () => {
   console.log(`Server running at ${address}:${port}/`);

--- a/backend/src/note.ts
+++ b/backend/src/note.ts
@@ -1,0 +1,78 @@
+import express from "express";
+import jwt from "jsonwebtoken";
+import { sdk as graphql } from "./index";
+import authenticate from "./authenticate";
+
+interface userJWTPayload {
+  uuid: string;
+  "https://hasura.io/jwt/claims": {
+    "x-hasura-allowed-roles": string[];
+    "x-hasura-default-role": string;
+  };
+}
+
+const router = express.Router();
+
+// 从 Authorization 请求头解析出用户 uuid
+const getUuidFromHeader = (req: express.Request): string | null => {
+  const authHeader = req.get("Authorization");
+  if (!authHeader) return null;
+  try {
+    const decoded = jwt.verify(
+      authHeader.substring(7),
+      process.env.JWT_SECRET!
+    ) as userJWTPayload;
+    return decoded.uuid ?? null;
+  } catch {
+    return null;
+  }
+};
+
+// GET /note?room=<room_uuid>：读取当前用户在该会议下的便签（不存在则返回空串）
+router.get("/", authenticate, async (req, res) => {
+  const user_uuid = getUuidFromHeader(req);
+  if (!user_uuid) {
+    return res.status(401).send("401 Unauthorized: Token expired or invalid");
+  }
+  const room_uuid = req.query.room as string | undefined;
+  if (!room_uuid) {
+    return res.status(422).send("422 Unprocessable Entity: Missing room");
+  }
+  try {
+    const result = await graphql.getNote({ user_uuid, room_uuid });
+    const note = result.note[0];
+    return res.status(200).json({
+      content: note?.content ?? "",
+      updated_at: note?.updated_at ?? null,
+    });
+  } catch (err) {
+    console.error(err);
+    return res.sendStatus(500);
+  }
+});
+
+// POST /note：保存（upsert）当前用户在该会议下的便签，每用户每会议仅一份
+router.post("/", authenticate, async (req, res) => {
+  const user_uuid = getUuidFromHeader(req);
+  if (!user_uuid) {
+    return res.status(401).send("401 Unauthorized: Token expired or invalid");
+  }
+  const { room, content } = req.body ?? {};
+  if (!room || typeof content !== "string") {
+    return res
+      .status(422)
+      .send("422 Unprocessable Entity: Missing room or content");
+  }
+  try {
+    const result = await graphql.upsertNote({ user_uuid, room_uuid: room, content });
+    return res.status(200).json({
+      content: result.insert_note_one?.content ?? "",
+      updated_at: result.insert_note_one?.updated_at ?? null,
+    });
+  } catch (err) {
+    console.error(err);
+    return res.sendStatus(500);
+  }
+});
+
+export default router;


### PR DESCRIPTION
第4讲 Backend 作业：便签纸后端路由

- GET /note?room=<uuid>：读取当前用户在该会议下的便签
- POST /note：upsert 保存，每用户每会议仅一份
- JWT 解析 user_uuid，鉴权失败 401、缺参 422
- graphql.ts 补 getNote/upsertNote（on_conflict 更新）

关联 issue：#7